### PR TITLE
Сontinue exporting videos in case of errors

### DIFF
--- a/vk_tg_converter/arguments.py
+++ b/vk_tg_converter/arguments.py
@@ -86,7 +86,7 @@ class ConverterArgumentsParser:
         if args.media_export_dir.exists():
             if not args.media_export_dir.is_dir():
                 self.parser.error(f"Output media path does not point to a directory: {args.media_export_dir}")
-            if any(True for _ in args.media_export_dir.iterdir()):
-                self.parser.error(f"Output media directory is not empty: {args.media_export_dir}")
+            # if any(True for _ in args.media_export_dir.iterdir()):
+            #     self.parser.error(f"Output media directory is not empty: {args.media_export_dir}")
         if (args.contacts_file_opt is None) and (args.input_file_opt is None):
             self.parser.error("You must not use --skip-contacts if you use --dummy-input")

--- a/vk_tg_converter/converters/media_converter.py
+++ b/vk_tg_converter/converters/media_converter.py
@@ -30,8 +30,8 @@ class MediaConverter(IMediaConverter):
     def __init__(self, api: VkApiMethod, video_downloader: IVideoDownloader, logger: Logger,
                  export_dir: Path, config: Config, disable_progress_bar: bool) -> None:
         export_dir.mkdir(parents=True, exist_ok=True)
-        if any(True for _ in export_dir.iterdir()):
-            raise ValueError(f"Directory is not empty: {export_dir}")
+        # if any(True for _ in export_dir.iterdir()):
+        #     raise ValueError(f"Directory is not empty: {export_dir}")
         self.export_dir = export_dir
         self.api = api
         self.video_downloader = video_downloader
@@ -51,6 +51,7 @@ class MediaConverter(IMediaConverter):
         for i, attch in enumerate(attachments):
             if isinstance(attch, vk.Video):
                 videos_with_idx.append((attch, i))
+                # pass
             elif self._is_non_video_supported(attch):
                 non_videos_with_idx.append((attch, i))
 
@@ -77,10 +78,12 @@ class MediaConverter(IMediaConverter):
         # Why logger.parent? I don't know, but None or just logger or logger.root don't fix the issue
         with logging_redirect_tqdm([self.logger.parent]):
             async with ClientSession() as session:
-                await asyncio.gather(non_videos_task(session))
+                # await asyncio.gather(non_videos_task(session))
+                # pass
                 # Running them in parallel doesn't really speed anything up
                 # Sequential run at least has better visualization
                 await asyncio.gather(videos_task(session))
+                # pass
         return result
 
     @staticmethod


### PR DESCRIPTION
[yt-dlp](https://github.com/yt-dlp/yt-dlp) (насколько я понял, эта программа используется для выкачивания видео) умеет корректно обрабатывать следующие ситуации:
- докачивать видео, в случае если произошёл обрыв связи
- пропускать уже скаченные видео.

Если во врямя экспорта видео происходят какие-то ошибки и  vk-tg-chat-transferring  останавливает свою работу, то для перезапуска требуется удалить всю папку с уже скачанными видео и начать всё сначала. Если медиа файлов планируется выкачать более чем на 200 Мб, то:
- Уже скаченные файлы придётся пытаться выкачивать снова
- Может повторно произойти ошибка во время скачивания, из-за чего всё придётся выкачивать сначала.

Текущий pull request - это только черновик. В нём:
- убрана проверка, что папка, куда будут скачиваться медиа файлы, не пуста (она не будет пустой после повторных попыток выкачать файлы).
- добавлены комментарии с операторами pass, чтобы отметить места в коде, где выполняется запуск скачивания видео файлов. Ими можно воспользоваться, чтобы скачать только фотографии с документами и исключить скачивание видео файлов.

Pull request требуется дорабатывать.

Здесь же заодно отмечу, что при запуске где-то 12.02.2024, при попытке скачать видео были ошибки yt-dlp, в которых было указано, что эту программу требуется обновить.